### PR TITLE
add kubectl binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ ENV BUILD_DIR      "$TMPDIR/build"
 ENV VAULT_VERSION    0.8.3
 ENV RUN_TESTS        false
 
+# build artifacts for kubectl
+export K8S_BASEURL=https://storage.googleapis.com/kubernetes-release/release
+export K8S_VER=v1.8.4
+
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
 ENV DOCKER_BASE_VERSION=0.0.4
@@ -63,6 +67,10 @@ RUN mkdir -p /vault/logs && \
     mkdir -p /vault/file && \
     mkdir -p /vault/config && \
     chown -R vault:vault /vault
+
+# install kubectl
+RUN curl -o /usr/local/bin/kubectl $K8S_BASEURL/$K8S_VER/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ENV VAULT_VERSION    0.8.3
 ENV RUN_TESTS        false
 
 # build artifacts for kubectl
-export K8S_BASEURL=https://storage.googleapis.com/kubernetes-release/release
-export K8S_VER=v1.8.4
+ENV K8S_BASEURL=https://storage.googleapis.com/kubernetes-release/release
+ENV K8S_VER=v1.8.4
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
This PR adds  kubectl binary to the container-vault image. This will allow vault init process to create secrets for each one of the master key shards, as well as the root token.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A

**Special notes for your reviewer**:
Any pod using this from the cluster will need the appropriate RBAC role/role binding/service account configuration. Vault chart will have the above combo locked down to only be able to create a secret with a certain name.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add  kubectl binary to the container-vault image to allow vault initialisation process to create secrets for each one of the master key shards, as well as the root token.
```
